### PR TITLE
Update to latest Minestom

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,8 +41,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
 
-    compileOnly("net.minestom:minestom-snapshots:a521c4e7cd")
-    testImplementation("net.minestom:minestom-snapshots:a521c4e7cd")
+    compileOnly("net.minestom:minestom-snapshots:f71ab6d851")
+    testImplementation("net.minestom:minestom-snapshots:f71ab6d851")
 }
 
 tasks.getByName<Test>("test") {

--- a/src/main/java/ca/atlasengine/projectiles/AbstractProjectile.java
+++ b/src/main/java/ca/atlasengine/projectiles/AbstractProjectile.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
 public abstract class AbstractProjectile extends Entity implements Projectile {
     protected final Entity shooter;
     protected PhysicsResult previousPhysicsResult;
-    private Pos previousPosition;
+    protected Pos previousPosition;
 
     public AbstractProjectile(EntityType type, Entity shooter) {
         super(type);
@@ -75,16 +75,16 @@ public abstract class AbstractProjectile extends Entity implements Projectile {
         if (previousPhysicsResult.hasCollision()) {
             Block hitBlock = null;
             Point hitPoint = null;
-            if (previousPhysicsResult.collisionShapes()[0] instanceof ShapeImpl block) {
-                hitBlock = block.block();
+            if (previousPhysicsResult.collisionShapes()[0] instanceof ShapeImpl) {
+                hitBlock = instance.getBlock(previousPhysicsResult.collisionPoints()[0].sub(0, Vec.EPSILON, 0), Block.Getter.Condition.TYPE);
                 hitPoint = previousPhysicsResult.collisionPoints()[0];
             }
-            if (previousPhysicsResult.collisionShapes()[1] instanceof ShapeImpl block) {
-                hitBlock = block.block();
+            if (previousPhysicsResult.collisionShapes()[1] instanceof ShapeImpl) {
+                hitBlock = instance.getBlock(previousPhysicsResult.collisionPoints()[1].sub(0, Vec.EPSILON, 0), Block.Getter.Condition.TYPE);
                 hitPoint = previousPhysicsResult.collisionPoints()[1];
             }
-            if (previousPhysicsResult.collisionShapes()[2] instanceof ShapeImpl block) {
-                hitBlock = block.block();
+            if (previousPhysicsResult.collisionShapes()[2] instanceof ShapeImpl) {
+                hitBlock = instance.getBlock(previousPhysicsResult.collisionPoints()[2].sub(0, Vec.EPSILON, 0), Block.Getter.Condition.TYPE);
                 hitPoint = previousPhysicsResult.collisionPoints()[2];
             }
 

--- a/src/main/java/ca/atlasengine/projectiles/entities/ArrowProjectile.java
+++ b/src/main/java/ca/atlasengine/projectiles/entities/ArrowProjectile.java
@@ -48,7 +48,7 @@ public class ArrowProjectile extends AbstractProjectile {
     }
 
     private void setup() {
-        this.hasCollision = false;
+        this.collidesWithEntities = false;
         if (getEntityMeta() instanceof ProjectileMeta projectileMeta) {
             projectileMeta.setShooter(this.shooter);
         }


### PR DESCRIPTION
- Bump Minestom version compiled against to latest
- Update AbstractProjectile block collisions (code is taken from Minestom's BlockCollision class)
- Update ArrowProjectile field
- Make previousPosition protected so it can be more easily extended

Fixes #2 