### PR TITLE
Abstract common collision logic across all Projectile implementations into AbstractProjectile

### DIFF
--- a/src/main/java/ca/atlasengine/projectiles/entities/ArrowProjectile.java
+++ b/src/main/java/ca/atlasengine/projectiles/entities/ArrowProjectile.java
@@ -1,11 +1,9 @@
 package ca.atlasengine.projectiles.entities;
 
 import ca.atlasengine.projectiles.AbstractProjectile;
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerFlag;
 import net.minestom.server.collision.Aerodynamics;
 import net.minestom.server.collision.BoundingBox;
-import net.minestom.server.collision.EntityCollisionResult;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
@@ -16,7 +14,6 @@ import net.minestom.server.entity.metadata.projectile.ProjectileMeta;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.entity.EntityShootEvent;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.instance.block.BlockHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Random;
@@ -29,7 +26,6 @@ public class ArrowProjectile extends AbstractProjectile {
 
     private boolean critical = false;
     private boolean firstTick = true;
-    private boolean inBlock = false;
 
     public boolean isCritical() {
         return critical;
@@ -125,32 +121,6 @@ public class ArrowProjectile extends AbstractProjectile {
                 setVelocity(v);
             }
         });
-    }
-
-    @Override
-    protected void handleBlockCollision(Block hitBlock, Point hitPos, Pos posBefore) {
-        velocity = Vec.ZERO;
-        setNoGravity(true);
-
-        inBlock = true;
-        velocity = Vec.fromPoint(hitPos.sub(posBefore));
-
-        Vec v = velocity.normalize().mul(0.01f); // required so the entity is lit (just outside the block)
-
-        // if the value is zero, it will be unlit. If the value is more than 0.01, there will be noticeable pitch change visually
-        position = new Pos(hitPos.x()-v.x(), hitPos.y()-v.y(), hitPos.z()-v.z(), posBefore.yaw(), posBefore.pitch());
-        MinecraftServer.getSchedulerManager().scheduleNextTick(this::synchronizePosition); // required as in rare situations there will be a slight disagreement with the client and server on if it hit or not | also scheduling next tick so it doesn't jump to the hit position until it has actually hit
-
-        callBlockCollisionEvent(Pos.fromPoint(hitPos), hitBlock);
-
-        BlockHandler blockHandler = hitBlock.handler();
-        if (blockHandler == null) return;
-        blockHandler.onTouch(new BlockHandler.Touch(hitBlock, instance, hitPos, this));
-    }
-
-    @Override
-    protected boolean handleEntityCollision(EntityCollisionResult result, Point hitPos, Pos posBefore) {
-        return callEntityCollisionEvent(Pos.fromPoint(hitPos), result.entity());
     }
 
     protected @NotNull Vec updateVelocity(@NotNull Pos entityPosition, @NotNull Vec currentVelocity, @NotNull Block.@NotNull Getter blockGetter, @NotNull Aerodynamics aerodynamics, boolean positionChanged, boolean entityFlying, boolean entityOnGround, boolean entityNoGravity) {

--- a/src/main/java/ca/atlasengine/projectiles/entities/FireballProjectile.java
+++ b/src/main/java/ca/atlasengine/projectiles/entities/FireballProjectile.java
@@ -1,10 +1,8 @@
 package ca.atlasengine.projectiles.entities;
 
 import ca.atlasengine.projectiles.AbstractProjectile;
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerFlag;
 import net.minestom.server.collision.Aerodynamics;
-import net.minestom.server.collision.EntityCollisionResult;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
@@ -13,27 +11,15 @@ import net.minestom.server.entity.EntityType;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.entity.EntityShootEvent;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.instance.block.BlockHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class FireballProjectile extends AbstractProjectile {
-    boolean inBlock = false;
-
     public FireballProjectile(EntityType type, Entity shooter) {
         super(type, shooter);
         this.setNoGravity(true);
-    }
-
-    @Override
-    public void tick(long time) {
-        if (removed || inBlock) return;
-
-        updatePosition(time);
-        callEntityCollision();
-        callBlockCollision();
     }
 
     @Override
@@ -84,30 +70,6 @@ public class FireballProjectile extends AbstractProjectile {
                 setVelocity(v);
             }
         });
-    }
-
-    @Override
-    protected void handleBlockCollision(Block hitBlock, Point hitPos, Pos posBefore) {
-        velocity = Vec.ZERO;
-        setNoGravity(true);
-
-        velocity = Vec.fromPoint(hitPos.sub(posBefore));
-        Vec v = velocity.normalize().mul(0.01f); // required so the entity is lit (just outside the block)
-
-        // if the value is zero, it will be unlit. If the value is more than 0.01, there will be noticeable pitch change visually
-        position = new Pos(hitPos.x()-v.x(), hitPos.y()-v.y(), hitPos.z()-v.z(), posBefore.yaw(), posBefore.pitch());
-        MinecraftServer.getSchedulerManager().scheduleNextTick(this::synchronizePosition); // required as in rare situations there will be a slight disagreement with the client and server on if it hit or not | also scheduling next tick so it doesn't jump to the hit position until it has actually hit
-
-        callBlockCollisionEvent(Pos.fromPoint(hitPos), hitBlock);
-
-        BlockHandler blockHandler = hitBlock.handler();
-        if (blockHandler == null) return;
-        blockHandler.onTouch(new BlockHandler.Touch(hitBlock, instance, hitPos, this));
-    }
-
-    @Override
-    protected boolean handleEntityCollision(EntityCollisionResult result, Point hitPos, Pos posBefore) {
-        return callEntityCollisionEvent(Pos.fromPoint(hitPos), result.entity());
     }
 
     protected @NotNull Vec updateVelocity(@NotNull Pos entityPosition, @NotNull Vec currentVelocity, @NotNull Block.@NotNull Getter blockGetter, @NotNull Aerodynamics aerodynamics, boolean positionChanged, boolean entityFlying, boolean entityOnGround, boolean entityNoGravity) {

--- a/src/main/java/ca/atlasengine/projectiles/entities/FollowProjectile.java
+++ b/src/main/java/ca/atlasengine/projectiles/entities/FollowProjectile.java
@@ -1,10 +1,8 @@
 package ca.atlasengine.projectiles.entities;
 
 import ca.atlasengine.projectiles.AbstractProjectile;
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerFlag;
 import net.minestom.server.collision.Aerodynamics;
-import net.minestom.server.collision.EntityCollisionResult;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
@@ -13,7 +11,6 @@ import net.minestom.server.entity.EntityType;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.entity.EntityShootEvent;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.instance.block.BlockHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Random;
@@ -23,8 +20,6 @@ public class FollowProjectile extends AbstractProjectile {
     private final Entity target;
     private final float attractionAcceleration;
     private final float attractionVelocity;
-
-    boolean inBlock = false;
 
     private long ticks = 0;
 
@@ -38,11 +33,7 @@ public class FollowProjectile extends AbstractProjectile {
 
     @Override
     public void tick(long time) {
-        if (removed || inBlock) return;
-
-        updatePosition(time);
-        callEntityCollision();
-
+        super.tick(time);
         ticks++;
     }
 
@@ -100,28 +91,6 @@ public class FollowProjectile extends AbstractProjectile {
                 setVelocity(v);
             }
         });
-    }
-
-    @Override
-    protected void handleBlockCollision(Block hitBlock, Point hitPos, Pos posBefore) {
-        velocity = Vec.ZERO;
-        setNoGravity(true);
-        inBlock = true;
-
-        // if the value is zero, it will be unlit. If the value is more than 0.01, there will be noticeable pitch change visually
-        position = new Pos(hitPos.x(), hitPos.y(), hitPos.z(), posBefore.yaw(), posBefore.pitch());
-        MinecraftServer.getSchedulerManager().scheduleNextTick(this::synchronizePosition); // required as in rare situations there will be a slight disagreement with the client and server on if it hit or not | also scheduling next tick so it doesn't jump to the hit position until it has actually hit
-
-        callBlockCollisionEvent(Pos.fromPoint(hitPos), hitBlock);
-
-        BlockHandler blockHandler = hitBlock.handler();
-        if (blockHandler == null) return;
-        blockHandler.onTouch(new BlockHandler.Touch(hitBlock, instance, hitPos, this));
-    }
-
-    @Override
-    protected boolean handleEntityCollision(EntityCollisionResult result, Point hitPos, Pos posBefore) {
-        return callEntityCollisionEvent(Pos.fromPoint(hitPos), result.entity());
     }
 
     protected @NotNull Vec updateVelocity(@NotNull Pos entityPosition, @NotNull Vec currentVelocity, @NotNull Block.@NotNull Getter blockGetter, @NotNull Aerodynamics aerodynamics, boolean positionChanged, boolean entityFlying, boolean entityOnGround, boolean entityNoGravity) {

--- a/src/main/java/ca/atlasengine/projectiles/entities/ThrownItemProjectile.java
+++ b/src/main/java/ca/atlasengine/projectiles/entities/ThrownItemProjectile.java
@@ -1,10 +1,8 @@
 package ca.atlasengine.projectiles.entities;
 
 import ca.atlasengine.projectiles.AbstractProjectile;
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerFlag;
 import net.minestom.server.collision.Aerodynamics;
-import net.minestom.server.collision.EntityCollisionResult;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
@@ -13,24 +11,14 @@ import net.minestom.server.entity.EntityType;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.entity.EntityShootEvent;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.instance.block.BlockHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class ThrownItemProjectile extends AbstractProjectile {
-    boolean inBlock = false;
-
     public ThrownItemProjectile(EntityType type, Entity shooter) {
         super(type, shooter);
-    }
-
-    @Override
-    public void tick(long time) {
-        if (removed || inBlock) return;
-        updatePosition(time);
-        callEntityCollision();
     }
 
     @Override
@@ -82,28 +70,6 @@ public class ThrownItemProjectile extends AbstractProjectile {
                 setVelocity(v);
             }
         });
-    }
-
-    @Override
-    protected void handleBlockCollision(Block hitBlock, Point hitPos, Pos posBefore) {
-        velocity = Vec.ZERO;
-        setNoGravity(true);
-        inBlock = true;
-
-        // if the value is zero, it will be unlit. If the value is more than 0.01, there will be noticeable pitch change visually
-        position = new Pos(hitPos.x(), hitPos.y(), hitPos.z(), posBefore.yaw(), posBefore.pitch());
-        MinecraftServer.getSchedulerManager().scheduleNextTick(this::synchronizePosition); // required as in rare situations there will be a slight disagreement with the client and server on if it hit or not | also scheduling next tick so it doesn't jump to the hit position until it has actually hit
-
-        callBlockCollisionEvent(Pos.fromPoint(hitPos), hitBlock);
-
-        BlockHandler blockHandler = hitBlock.handler();
-        if (blockHandler == null) return;
-        blockHandler.onTouch(new BlockHandler.Touch(hitBlock, instance, hitPos, this));
-    }
-
-    @Override
-    protected boolean handleEntityCollision(EntityCollisionResult result, Point hitPos, Pos posBefore) {
-        return callEntityCollisionEvent(Pos.fromPoint(hitPos), result.entity());
     }
 
     protected @NotNull Vec updateVelocity(@NotNull Pos entityPosition, @NotNull Vec currentVelocity, @NotNull Block.@NotNull Getter blockGetter, @NotNull Aerodynamics aerodynamics, boolean positionChanged, boolean entityFlying, boolean entityOnGround, boolean entityNoGravity) {


### PR DESCRIPTION
This PR extracts the contents of the `handleBlockCollision` and `handleEntityCollision` methods and the `inBlock` field into `AbstractProjectile`. It also moves the implementation of `tick` into `AbstractProjectile` for all Projectile classes except ArrowProjectile. This removes a lot of code duplication among `AbstractProjectile`'s subclasses.

This does result in some behavior changes, both of which I believe to be bug fixes:
1. `ThrownItemProjectile` and `FollowProjectile` now call `callBlockCollision` every tick, which means they will fire block collision events when they collide with blocks.
2. FireballProjectile will only call `callBlockCollision` if the result of `callEntityCollision` is false. Previously, both methods were called regardless of the result of `callBlockCollision`. This change makes it consistent with the other projectile implementations.