### PR TITLE
Fix block collisions when a projectile enters an unloaded chunk

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ publishing {
     publications.create<MavenPublication>("maven") {
         groupId = "ca.atlasengine"
         artifactId = "atlas-projectiles"
-        version = "1.0.2"
+        version = "2.1.3"
 
         from(components["java"])
     }
@@ -41,8 +41,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
 
-    compileOnly("net.minestom:minestom-snapshots:c96413678c")
-    testImplementation("net.minestom:minestom-snapshots:c96413678c")
+    compileOnly("net.minestom:minestom-snapshots:1_21_5-2398778b46")
+    testImplementation("net.minestom:minestom-snapshots:1_21_5-2398778b46")
 }
 
 tasks.getByName<Test>("test") {

--- a/src/main/java/ca/atlasengine/projectiles/AbstractProjectile.java
+++ b/src/main/java/ca/atlasengine/projectiles/AbstractProjectile.java
@@ -66,7 +66,7 @@ public abstract class AbstractProjectile extends Entity implements Projectile {
         if (vehicle != null) return;
 
         this.previousPosition = position;
-        final Block.Getter chunkCache = new ChunkCache(instance, currentChunk, Block.STONE);
+        final Block.Getter chunkCache = new ChunkCache(instance, currentChunk);
         PhysicsResult result = computePhysics(
                 position, velocity.div(ServerFlag.SERVER_TICKS_PER_SECOND),
                 chunkCache, getAerodynamics());

--- a/src/test/java/Main.java
+++ b/src/test/java/Main.java
@@ -7,6 +7,7 @@ import net.kyori.adventure.text.format.TextColor;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.adventure.audience.Audiences;
 import net.minestom.server.command.CommandManager;
+import net.minestom.server.component.DataComponents;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.*;
 import net.minestom.server.event.GlobalEventHandler;
@@ -17,7 +18,6 @@ import net.minestom.server.instance.InstanceContainer;
 import net.minestom.server.instance.InstanceManager;
 import net.minestom.server.instance.LightingChunk;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.item.ItemComponent;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.server.monitoring.TickMonitor;
@@ -66,7 +66,7 @@ public class Main {
                 final Player player = event.getPlayer();
 
                 var bow = ItemStack.builder(Material.BOW)
-                                  .set(ItemComponent.CHARGED_PROJECTILES, List.of(ItemStack.of(Material.ARROW)))
+                                  .set(DataComponents.CHARGED_PROJECTILES, List.of(ItemStack.of(Material.ARROW)))
                                   .build();
 
                 player.setItemInMainHand(bow);


### PR DESCRIPTION
I was using `ThrownItemProjectile` to implement ender pearls, but when the projectile enters an unloaded chunk, it immediately triggers a block collision, causing the player to be teleported into the air.

This occurs because the `ChunkCache` passed to the physics calculation uses stone as a default block if the chunk is unloaded:
https://github.com/AtlasEngineCa/AtlasProjectiles/blob/b073b38846151bb5bb98dad231826c3fb2b04371/src/main/java/ca/atlasengine/projectiles/AbstractProjectile.java#L69

We can fix this by removing the parameter, which will change the default block to air.

I suspect this isn't an issue if the projectile is already in an unloaded chunk because the chunk is [checked before calling `movementTick`](https://github.com/AtlasEngineCa/AtlasProjectiles/blob/b073b38846151bb5bb98dad231826c3fb2b04371/src/main/java/ca/atlasengine/projectiles/AbstractProjectile.java#L149), but block collisions can still be triggered when moving from a loaded chunk into an unloaded chunk.

Here's a simple example to illustrate the issue:
```java
MinecraftServer.getGlobalEventHandler().addListener(PlayerSpawnEvent.class, event -> {
    if (!event.isFirstSpawn()) return;
    final Player player = event.getPlayer();

    player.getInventory().addItemStack(ItemStack.of(Material.ENDER_PEARL, 16));

    player.eventNode().addListener(PlayerUseItemEvent.class, e -> {
        if (e.getHand() != PlayerHand.MAIN) return;
        if (e.getItemStack().material() == Material.ENDER_PEARL) {
            ThrownItemProjectile projectile = new ThrownItemProjectile(EntityType.ENDER_PEARL, e.getPlayer());
            projectile.shoot(e.getPlayer().getPosition().add(0, e.getPlayer().getEyeHeight(), 0).asVec(), 10, 1);
            projectile.eventNode().addListener(ProjectileCollideWithBlockEvent.class, collideEvent -> {
                Pos pos = collideEvent.getCollisionPosition().add(0.0, 1.0, 0.0);
                player.teleport(pos);
            });
        }
    });
});
```

Throw the ender pearl far and at a high angle. With this change, the ender pearl doesn't land, but without the change, the player gets teleported midair when the pearl crosses over the boundary between loaded and unloaded chunks.

I also updated the AtlasProjectiles and Minestom versions. Let me know if you want me to revert those changes.